### PR TITLE
fix missing posters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# plugin.video.hdtrailers_net
+XBMC video plugin to browse trailers and clips from www.hd-trailers.net
+
+Fork from the original plugin with updated URLs to fetch covers from https and not http (which doesn't work anymore)

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.hdtrailers_net" name="HD-Trailers.net" version="1.2.2" provider-name="Tristan Fischer (sphere@dersphere.de)">
+<addon id="plugin.video.hdtrailers_net" name="HD-Trailers.net" version="1.2.3" provider-name="Tristan Fischer (sphere@dersphere.de)">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
     <import addon="script.module.xbmcswift2" version="2.4.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+1.2.3 (02.01.2016)
+- fix URLs of posters in scraper code
+
 1.2.2 (16.03.2014)
 - updated translations
 

--- a/resources/lib/scraper.py
+++ b/resources/lib/scraper.py
@@ -87,7 +87,7 @@ def get_videos(movie_id):
     span = tree.find('span', {'class': 'topTableImage'})
     movie = {
         'title': span.img['title'],
-        'thumb': span.img['src']
+        'thumb': 'http:' + span.img['src']
     }
 
     table = tree.find('table', {'class': 'bottomTable'})
@@ -142,7 +142,7 @@ def _get_movies(url):
     movies = [{
         'id': td.a['href'].split('/')[2],
         'title': td.a.img['alt'],
-        'thumb': td.a.img['src']
+        'thumb': 'http:' + td.a.img['src']
     } for td in tree.findAll('td', 'indexTableTrailerImage') if td.a.img]
     has_next_page = tree.find(
         'a',

--- a/resources/lib/scraper.py
+++ b/resources/lib/scraper.py
@@ -25,7 +25,7 @@ URL_PROTO = 'https:'
 MAIN_URL = URL_PROTO + '//www.hd-trailers.net/'
 NEXT_IMG = URL_PROTO + '//static.hd-trailers.net/images/mobile/next.png'
 PREV_IMG = URL_PROTO + '//static.hd-trailers.net/images/mobile/prev.png'
-USER_AGENT = 'XBMC Add-on HD-Trailers.net v1.1.1'
+USER_AGENT = 'Kodi Add-on HD-Trailers.net v1.2.3'
 
 SOURCES = (
     'apple.com',

--- a/resources/lib/scraper.py
+++ b/resources/lib/scraper.py
@@ -21,10 +21,11 @@ import json
 import urllib2
 from BeautifulSoup import BeautifulSoup
 
-MAIN_URL = 'http://www.hd-trailers.net/'
-NEXT_IMG = 'http://static.hd-trailers.net/images/mobile/next.png'
-PREV_IMG = 'http://static.hd-trailers.net/images/mobile/prev.png'
-USER_AGENT = 'XBMC Add-on HD-Trailers.net v1.1.0'
+URL_PROTO = 'https:'
+MAIN_URL = URL_PROTO + '//www.hd-trailers.net/'
+NEXT_IMG = URL_PROTO + '//static.hd-trailers.net/images/mobile/next.png'
+PREV_IMG = URL_PROTO + '//static.hd-trailers.net/images/mobile/prev.png'
+USER_AGENT = 'XBMC Add-on HD-Trailers.net v1.1.1'
 
 SOURCES = (
     'apple.com',
@@ -87,7 +88,7 @@ def get_videos(movie_id):
     span = tree.find('span', {'class': 'topTableImage'})
     movie = {
         'title': span.img['title'],
-        'thumb': 'http:' + span.img['src']
+        'thumb': URL_PROTO + span.img['src']
     }
 
     table = tree.find('table', {'class': 'bottomTable'})
@@ -142,7 +143,7 @@ def _get_movies(url):
     movies = [{
         'id': td.a['href'].split('/')[2],
         'title': td.a.img['alt'],
-        'thumb': 'http:' + td.a.img['src']
+        'thumb': URL_PROTO + td.a.img['src']
     } for td in tree.findAll('td', 'indexTableTrailerImage') if td.a.img]
     has_next_page = tree.find(
         'a',


### PR DESCRIPTION
For quite some time, posters doesn't work anymore with this plugin because hd-trailers.net seems to have changed its URLs from "http://something" to "//something" in the img tags of the posters.
This pull request aims to fix that and I added a variable named URL_PROTO to be able to switch easily between http and https.
Changed version in addon.xml and updated changelog.txt and user-agent in scraper code.